### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 A react, redux, webpack, css modules, postcss, karma and mocha boilerplate. Complete with super simple authentication flow, tests on reducers and components. Related to [blogpost](http://pebblecode.com/blog/react-redux-unit-testing/). Complete with redux dev tools. ctrl-h and ctrl-q shortcuts :)
 
-##Installation
-####npm3 and node v4+ required
+## Installation
+#### npm3 and node v4+ required
 ``` git clone git@github.com:export-mike/react-redux-boilerplate.git```
 
 ```npm i ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
